### PR TITLE
Make django-mailer Python 3 installable.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 
 setup(


### PR DESCRIPTION
The goal of this branch is to sprinkle in just enough metadata to make this Python 3 installable so it doesn't block tox from running on the `py36` env.

I doubt the package actually works on Python 3, but that's not the objective for this change.